### PR TITLE
Proposed update for script.pine

### DIFF
--- a/script.pine
+++ b/script.pine
@@ -106,7 +106,7 @@ method stripPrefix(string sym) =>
     int colon = str.pos(sym, ":")
     colon != -1 ? str.substring(sym, colon + 1) : sym
 
-isDivergenceA(bool ignoreSwitch) =>
+isDivergenceA() =>
     smtOK = false
     zg.Pivot pvtK0 = na
     float pvtK0y   = na
@@ -154,7 +154,7 @@ isDivergenceA(bool ignoreSwitch) =>
                 break
     [smtOK, pvtK0, pvtK1, pvtZ]
 
-isDivergenceB(bool ignoreSwitch) =>
+isDivergenceB() =>
     smtOK = false
     zg.Pivot pvtK0 = na
     float pvtK0y   = na
@@ -202,8 +202,8 @@ isDivergenceB(bool ignoreSwitch) =>
                 break
     [smtOK, pvtK0, pvtK1, pvtZ]
 
-[isCurrentSMTA, pvtK0A, pvtK1A, pvtZA] = isDivergenceA(true)
-[isCurrentSMTB, pvtK0B, pvtK1B, pvtZB] = isDivergenceB(false)
+[isCurrentSMTA, pvtK0A, pvtK1A, pvtZA] = isDivergenceA()
+[isCurrentSMTB, pvtK0B, pvtK1B, pvtZB] = isDivergenceB()
 
 type smtLinkCalc
     chart.point anchorA
@@ -386,7 +386,7 @@ method checkInvalidation(array<smtLinkDraw> smtDrawArr, symbol) =>
             bP = smtD.data.anchorB.price
             topDot = math.sign(smtD.data.dir) == 1
             aPS = topDot ? request.security(symbol, timeframe.period, high)[bar_index - smtD.data.anchorA.index] : request.security(symbol, timeframe.period, low)[bar_index - smtD.data.anchorA.index]
-            bPS = topDot ? request.security(symbol, timeframe.period, high)[bar_index - smtD.data.anchorB.index] : request.security(symbol, timeframe.period, low)[bar_index - smtD.data.anchorA.index]
+            bPS = topDot ? request.security(symbol, timeframe.period, high)[bar_index - smtD.data.anchorB.index] : request.security(symbol, timeframe.period, low)[bar_index - smtD.data.anchorB.index]
             hS = request.security(symbol, timeframe.period, high)
             lS = request.security(symbol, timeframe.period, low)
             if ((smtD.data.dir == 1 and aP < bP and high > bP) or 
@@ -408,7 +408,7 @@ method checkValidation(array<smtLinkDraw> smtDrawArr, symbol) =>
             zP = smtD.data.anchorZ.price
             topDot = math.sign(smtD.data.dir) == 1
             aPS = topDot ? request.security(symbol, timeframe.period, high)[bar_index - smtD.data.anchorA.index] : request.security(symbol, timeframe.period, low)[bar_index - smtD.data.anchorA.index]
-            bPS = topDot ? request.security(symbol, timeframe.period, high)[bar_index - smtD.data.anchorB.index] : request.security(symbol, timeframe.period, low)[bar_index - smtD.data.anchorA.index]
+            bPS = topDot ? request.security(symbol, timeframe.period, high)[bar_index - smtD.data.anchorB.index] : request.security(symbol, timeframe.period, low)[bar_index - smtD.data.anchorB.index]
             zPS = topDot ? request.security(symbol, timeframe.period, high)[bar_index - smtD.data.anchorZ.index] : request.security(symbol, timeframe.period, low)[bar_index - smtD.data.anchorZ.index]
             hS = request.security(symbol, timeframe.period, high)
             lS = request.security(symbol, timeframe.period, low)


### PR DESCRIPTION
- [x] Review PR changes
- [x] Remove unused `ignoreSwitch` parameter from `isDivergenceA` and `isDivergenceB`
- [x] Fix `bPS` bug in `checkInvalidation` and `checkValidation` (bearish case incorrectly used `anchorA.index` instead of `anchorB.index`, causing correlated-symbol invalidation/validation to silently fail for all bearish SMTs)

Initial message: (please do not edit in the future)

**This change in the script addresses #1, while also optimizing the script further.**

The initial way the script worked was by comparing absolutely every pivot (both those on top and on the bottom), like so:

<img width="2475" height="1317" alt="image" src="https://github.com/user-attachments/assets/c849b3c1-8ad6-43b5-b675-d37122210e9a" />

While this technically works, this also introduces some issues. Due to the way the logic works, if an SMT between, say, dot 1 and 3 is detected before an SMT on dot 0 and 4, even though an SMT on dot 0 and 4 would have been detected, the loop breaks before it's able to check for that. This way of checking for SMTs is also redundant and adds unnecessary loading time.

We can fix this by changing the script like so. Making it so the loop only checks for the top dots, since the direction switching every couple bars will by itself make sure both the high and low SMTs are detected. This also roughly halves the execution time of the loop, since we no longer unnecessarily check for both at the same time.

This fixes the issue because now, since we only check 1 side at a time, the loop will stop where it makes sense to stop, avoiding missed early detections.